### PR TITLE
feat(marts): INT well-year dedup + tests (H4.S2)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+# .editorconfig
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# .gitattributes
+* text=auto eol=lf

--- a/dbt/models/marts/int/int_annual_production_dedup.sql
+++ b/dbt/models/marts/int/int_annual_production_dedup.sql
@@ -1,0 +1,94 @@
+{{--
+  Model: int_annual_production_dedup
+  Layer: MARTS (INT)
+  Grain: (api_well_number, reporting_year)
+
+  Business rules:
+    - Aggregate measures by well-year:
+        * SUM(oil_produced_bbl, gas_produced_mcf, water_produced_bbl) with COALESCE(0)
+        * MAX(months_in_production), then cap to 12
+    - Carry representative attributes from the row with the highest months_in_production
+      (ties broken by higher (oil+gas+water) and non-null attributes)
+    - Keep a helper field: records_aggregated
+--}}
+
+{{ config(materialized='view') }}
+
+with base as (
+    select *
+    from {{ ref('stg_annual_production') }}
+),
+
+agg as (
+    select
+        api_well_number,
+        reporting_year,
+        sum(coalesce(oil_produced_bbl, 0))  as oil_produced_bbl,
+        sum(coalesce(gas_produced_mcf, 0))  as gas_produced_mcf,
+        sum(coalesce(water_produced_bbl, 0)) as water_produced_bbl,
+        max(months_in_production)           as months_in_production_raw,
+        -- cap to 12 for business logic
+        least(12, max(coalesce(months_in_production, 0))) as months_in_production,
+        count(*) as records_aggregated
+    from base
+    group by 1,2
+),
+
+ranked as (
+    select
+        b.*,
+        -- tie-break rules:
+        --   1) higher months_in_production (NULLS LAST)
+        --   2) higher sum of measures
+        --   3) presence of descriptive attributes (non-null first)
+        row_number() over (
+            partition by b.api_well_number, b.reporting_year
+            order by
+                b.months_in_production desc nulls last,
+                (coalesce(b.oil_produced_bbl,0) + coalesce(b.gas_produced_mcf,0) + coalesce(b.water_produced_bbl,0)) desc,
+                case when b.well_name              is not null then 0 else 1 end,
+                case when b.company_name           is not null then 0 else 1 end,
+                case when b.production_field       is not null then 0 else 1 end,
+                case when b.producing_formation    is not null then 0 else 1 end
+        ) as pick_rank
+    from base b
+),
+
+rep as (
+    select
+        api_well_number,
+        reporting_year,
+        well_status_code,
+        well_type_code,
+        company_name,
+        county,
+        town,
+        production_field,
+        producing_formation,
+        well_name,
+        new_georeferenced_column
+    from ranked
+    where pick_rank = 1
+)
+
+select
+    a.api_well_number,
+    a.reporting_year,
+    a.months_in_production,         -- capped 0..12
+    a.oil_produced_bbl,
+    a.gas_produced_mcf,
+    a.water_produced_bbl,
+    r.well_status_code,
+    r.well_type_code,
+    r.company_name,
+    r.county,
+    r.town,
+    r.production_field,
+    r.producing_formation,
+    r.well_name,
+    r.new_georeferenced_column,
+    a.records_aggregated
+from agg a
+left join rep r
+  on r.api_well_number = a.api_well_number
+ and r.reporting_year  = a.reporting_year

--- a/dbt/models/marts/schema.yml
+++ b/dbt/models/marts/schema.yml
@@ -1,0 +1,39 @@
+version: 2
+
+models:
+  - name: int_annual_production_dedup
+    description: >
+      Intermediate view that deduplicates well-year rows and aggregates measures.
+      Representative attributes are taken from the row with the highest months_in_production.
+    columns:
+      - name: api_well_number
+        description: "API well identifier."
+        tests:
+          - not_null
+
+      - name: reporting_year
+        description: "Reporting year."
+        tests:
+          - not_null
+
+      - name: months_in_production
+        description: "Capped to 12 after aggregation."
+        tests:
+          - between_inclusive:
+              min_value: 0
+              max_value: 12
+
+      - name: oil_produced_bbl
+        description: "Aggregated oil (bbl) per well-year."
+        tests:
+          - non_negative
+
+      - name: gas_produced_mcf
+        description: "Aggregated gas (Mcf) per well-year."
+        tests:
+          - non_negative
+
+      - name: water_produced_bbl
+        description: "Aggregated water (bbl) per well-year."
+        tests:
+          - non_negative

--- a/dbt/models/staging/stg_annual_production.yml
+++ b/dbt/models/staging/stg_annual_production.yml
@@ -12,14 +12,18 @@ models:
           - not_null
 
       - name: reporting_year
-        description: "Reporting year."
+        description: "Reporting year. Must not be in the future."
         tests:
           - not_null
+          - non_future_year:
+              severity: error
 
       - name: months_in_production
         description: "Months in production (0..12 typically)."
         tests:
-          - non_negative:
+          - between_inclusive:
+              min_value: 0
+              max_value: 12
               severity: warn
 
       - name: gas_produced_mcf
@@ -27,17 +31,26 @@ models:
         tests:
           - non_negative:
               severity: warn
+          - max_null_proportion:
+              max_prop: 0.6
+              severity: warn
 
       - name: water_produced_bbl
         description: "Water produced (bbl)."
         tests:
           - non_negative:
               severity: warn
+          - max_null_proportion:
+              max_prop: 0.6
+              severity: warn
 
       - name: oil_produced_bbl
         description: "Oil produced (bbl)."
         tests:
           - non_negative:
+              severity: warn
+          - max_null_proportion:
+              max_prop: 0.6
               severity: warn
 
       - name: well_status_code

--- a/dbt/tests/generic/between_inclusive.sql
+++ b/dbt/tests/generic/between_inclusive.sql
@@ -1,0 +1,7 @@
+-- dbt/tests/generic/between_inclusive.sql
+{% test between_inclusive(model, column_name, min_value, max_value) %}
+select *
+from {{ model }}
+where {{ column_name }} < {{ min_value }}
+   or {{ column_name }} > {{ max_value }}
+{% endtest %}

--- a/dbt/tests/generic/max_null_proportion.sql
+++ b/dbt/tests/generic/max_null_proportion.sql
@@ -1,0 +1,26 @@
+-- dbt/tests/generic/max_null_proportion.sql
+-- Fails when NULL ratio for column_name exceeds max_prop (0..1).
+{% test max_null_proportion(model, column_name, max_prop) %}
+with stats as (
+  select
+    count(*) as total_rows,
+    sum(case when {{ column_name }} is null then 1 else 0 end) as null_rows
+  from {{ model }}
+),
+viol as (
+  select
+    total_rows, null_rows,
+    null_rows::float / null_rows::float + (total_rows - null_rows)::float as dummy -- avoid division by zero on compile
+  from stats
+),
+ratio as (
+  select
+    total_rows,
+    null_rows,
+    case when total_rows = 0 then 0.0 else null_rows::float / total_rows::float end as null_ratio
+  from stats
+)
+select *
+from ratio
+where null_ratio > {{ max_prop }}
+{% endtest %}

--- a/dbt/tests/generic/non_future_year.sql
+++ b/dbt/tests/generic/non_future_year.sql
@@ -1,0 +1,6 @@
+-- dbt/tests/generic/non_future_year.sql
+{% test non_future_year(model, column_name) %}
+select *
+from {{ model }}
+where {{ column_name }} > date_part(year, current_date())
+{% endtest %}

--- a/dbt/tests/int_annual_production_dedup_unique.sql
+++ b/dbt/tests/int_annual_production_dedup_unique.sql
@@ -1,0 +1,7 @@
+-- Fails if there are duplicate well-year rows after dedup
+select
+  api_well_number,
+  reporting_year
+from {{ ref('int_annual_production_dedup') }}
+group by 1,2
+having count(*) > 1

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -6,8 +6,6 @@ config-version: 2
 profile: "oil_gas_profile"
 
 # Put artifacts under /dbt
-target-path: "dbt/target"
-log-path: "dbt/logs"
 clean-targets: ["dbt/target", "dbt/logs"]
 
 # Paths are relative to THIS file

--- a/docs/marts_ERD.md
+++ b/docs/marts_ERD.md
@@ -1,0 +1,152 @@
+# Oil & Gas Marts Design (ERD & Business Rules)
+
+## Purpose & Scope
+This document defines the dimensional model (star schema) for the analytics layer (“marts”) of the **oil-gas-dashboard** project. It covers grains, SCD approach, deduplication logic, KPIs, and testing strategy.
+
+## Source Summary
+- Primary source: `RAW.ANNUAL_PRODUCTION` (loaded from CSV via `write_pandas`).
+- Known issues:
+  - ~796 duplicate rows at the `(api_well_number, reporting_year)` grain.
+  - Case-sensitive raw column names (quoted lowercase in Snowflake).
+  - Domain irregularities in status/type codes and month ranges (handled as warnings in staging).
+
+## Star Schema Overview
+**Grain:**
+- Fact table `fct_annual_production` at **well-year** grain.
+
+**Dimensions:**
+- `dim_well`: 1 row per well (API well number).
+- `dim_year`: 1 row per year.
+
+**Fact:**
+- `fct_annual_production`: one row per `(well, reporting_year)` with production metrics.
+
+### ERD (logical)
+```
+dim_well (well_sk) 1 ────* fct_annual_production (*well_sk, *year_sk, measures...)
+dim_year (year_sk) 1 ────*
+```
+
+## Keys & Surrogate Keys
+- Natural key for wells: `api_well_number`.
+- Surrogate keys:
+  - `well_sk`: deterministic hash of `api_well_number` (e.g., `md5`).
+  - `year_sk`: `reporting_year` (int) or hash of year; simplest is `reporting_year` itself.
+
+> We may adopt `dbt_utils.surrogate_key` later; for now we can use `md5(api_well_number)`.
+
+## Deduplication Strategy (Business Rules)
+Duplicates exist at `(api_well_number, reporting_year)`. We will **aggregate** duplicates into a single row per `(well, year)` with the following rules:
+
+- `oil_produced_bbl`, `gas_produced_mcf`, `water_produced_bbl`: **SUM** with `NULL` treated as 0 (i.e., `coalesce` in SQL).
+- `months_in_production`: **MAX** (bounded to `[0,12]` after aggregation).
+- Descriptive attributes (e.g., `well_name`, `county`, `town`, `well_type_code`, `well_status_code`, `producing_formation`, `production_field`):
+  - Prefer the **most frequent non-null** value across duplicates (tie-breaker: choose the value from the row with greatest `months_in_production`, then lexicographically).
+  - If this is too heavy for v1, fallback: take the **non-null value from the row with max `months_in_production`**, else first non-null.
+
+> Rationale: aggregating production metrics preserves totals; choosing representative attributes avoids inconsistent labels across duplicates.
+
+## Dimensions
+
+### `dim_well`
+- **Grain**: 1 row per `api_well_number`.
+- **Columns**:
+  - `well_sk` (PK, md5 of `api_well_number`)
+  - `api_well_number` (NK)
+  - `well_name`
+  - `company_name`
+  - `county`, `town`
+  - `producing_formation`, `production_field`
+  - `well_type_code`, `well_type_desc` (via mapping seed)
+  - `well_status_code`, `well_status_desc` (via mapping seed)
+  - (optional) `first_reporting_year`, `last_reporting_year`
+- **Population rule**: derive from the **deduplicated** intermediate (latest non-null values by year, or the "representative" record as defined above).
+- **SCD**: Type 1 (overwrite); we do not track history by design for v1.
+
+### `dim_year`
+- **Grain**: 1 row per year present in data.
+- **Columns**:
+  - `year_sk` (int, same as `reporting_year`)
+  - `is_current_year` (flag)
+  - `is_2001_plus` (flag)
+  - (optional) `decade`, etc.
+
+## Fact
+
+### `fct_annual_production`
+- **Grain**: 1 row per `well_sk` + `year_sk`.
+- **Columns**:
+  - Keys: `well_sk`, `year_sk`
+  - Measures:
+    - `oil_produced_bbl` (float)
+    - `gas_produced_mcf` (float)
+    - `water_produced_bbl` (float)
+    - `months_in_production` (int, 0..12)
+  - Degenerate / convenience attributes:
+    - `api_well_number` (degenerate for quick filters)
+    - `reporting_year`
+    - `county` (optional copy for quick slicing)
+- **Tests**:
+  - `unique` on (`well_sk`, `year_sk`)
+  - `not_null` on both keys and `reporting_year`
+  - `non_negative` on measures
+  - `between_inclusive` 0..12 on `months_in_production`
+
+## Code Mapping (Seeds)
+Provide seed tables to map short codes to human-readable descriptions (to be joined in `dim_well`).
+
+**`well_status_codes.csv`**
+```csv
+well_status_code,well_status_desc
+AC,Active
+IN,Inactive
+NR,Never Reported
+PA,Plugged & Abandoned
+VP,Voided Permit
+```
+
+**`well_type_codes.csv`**
+```csv
+well_type_code,well_type_desc
+GD,Gas Development
+OD,Oil Development
+NL,Not Listed / Unknown
+```
+
+> If unknown codes appear, keep the code and set description to `Unknown`.
+
+## KPI Views
+
+### `top_10_wells_by_oil`
+- For a selected year (parameterized or latest), rank wells by `oil_produced_bbl` and return top 10 with well attributes.
+
+### `wells_active_inactive`
+- Annual counts of wells by `well_status_code`/`well_status_desc`.
+
+### `non_productive_wells`
+- Definition (v1): wells with **zero** oil and **zero** gas for the year (or `months_in_production = 0`).
+- Output: list of wells per year with zero production; useful for quality checks or operational filtering.
+
+> We avoid “non_profitable” because profitability requires price/cost context that we don’t have.
+
+## Materialization Strategy
+- `dim_*` and `fct_*`: `table`
+- `int_*`: `view` for v1 (debuggability), potentially `ephemeral` in v2 for performance.
+- `kpi_*`: `view`
+
+## Performance Considerations (Snowflake)
+- Consider a **cluster key** on `fct_annual_production(reporting_year)` if queries are mostly year-filtered.
+- Facts are small (annual), so v1 can skip clustering safely.
+
+## Tests & Documentation (dbt)
+- Add `schema.yml` in `marts` with:
+  - `unique` and `not_null` on keys, `non_negative` on measures, `between_inclusive` on months.
+  - Column-level descriptions.
+- Keep staging tests as warnings; enforce stricter rules in marts (e.g., `error` on negative measures).
+
+## Implementation Plan (next steps)
+1. **INT**: `int_annual_production_dedup` (group by well + year; resolve duplicates and pick representative attributes).
+2. **DIM**: `dim_well` (from INT + mappings); `dim_year`.
+3. **FCT**: `fct_annual_production` (join INT to dims).
+4. **KPI**: `top_10_wells_by_oil`, `wells_active_inactive`, `non_productive_wells`.
+5. Add `schema.yml` tests for marts and seeds for code mappings.

--- a/run_pipeline.sh
+++ b/run_pipeline.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 LOG_TS(){ echo "[$(date -Iseconds)] $*"; }
 
-# Cargar variables si hay .env (ignora si no existe)
+# Load variables
 if [ -f ".env" ]; then
   # shellcheck disable=SC2046
   export $(grep -v '^#' .env | xargs -d '\n' -r) || true


### PR DESCRIPTION
Summary
This PR delivers H4.S2 of the roadmap:

Introduces the INT layer for annual production by deduplicating the (well, year) grain and applying business rules.

Adds data-quality tests aligned with H3.5 (business-level checks).

Includes the MARTS ERD document for maintainers and BI consumers.

It also carries recent H3.5 changes (staging business tests and artifact routing via env vars), already merged in this feature branch.