### PR TITLE
feat(marts): add dim_year table with docs and tests (H4.S3)

### DIFF
--- a/dbt/models/marts/dim/dim_year.sql
+++ b/dbt/models/marts/dim/dim_year.sql
@@ -1,0 +1,34 @@
+{{--
+  Model: dim_year
+  Layer: MARTS (DIM)
+  Grain: one row per reporting year present in INT
+  Source: int_annual_production_dedup (distinct reporting_year)
+
+  Notes:
+  - year_sk doubles as the business key (reporting_year).
+  - Flags are handy for BI filters (current year / recent years / decade).
+--}}
+
+{{ config(materialized='table') }}
+
+with years as (
+    select distinct
+        cast(reporting_year as number(38,0)) as year_sk
+    from {{ ref('int_annual_production_dedup') }}
+    where reporting_year is not null
+),
+
+final as (
+    select
+        year_sk,
+        year_sk                                              as year,
+        /* Snowflake date functions for dynamic flags */
+        case when year_sk = date_part('year', current_date()) then true else false end as is_current_year,
+        case when year_sk >= date_part('year', current_date()) - 4 then true else false end as is_last_5_years,
+        /* Decade helpers */
+        floor(year_sk/10)*10                                 as decade_start,
+        to_varchar(floor(year_sk/10)*10) || 's'              as decade_label
+    from years
+)
+
+select * from final

--- a/dbt/models/marts/schema.yml
+++ b/dbt/models/marts/schema.yml
@@ -37,3 +37,33 @@ models:
         description: "Aggregated water (bbl) per well-year."
         tests:
           - non_negative
+
+  - name: dim_year
+    description: >
+      Year dimension derived from years present in INT. Provides convenience flags
+      for current year, last 5 years, and decade bucketing.
+    columns:
+      - name: year_sk
+        description: "Surrogate/business key for the year (same as reporting_year)."
+        tests:
+          - not_null
+          - unique
+
+      - name: year
+        description: "Alias of year_sk for readability."
+        tests:
+          - not_null
+
+      - name: is_current_year
+        description: "True if equals current_date() year in Snowflake."
+
+      - name: is_last_5_years
+        description: "True if within the last 5 years relative to current_date()."
+
+      - name: decade_start
+        description: "Start of the decade (e.g., 2010)."
+        tests:
+          - not_null
+
+      - name: decade_label
+        description: "Text label for decade (e.g., '2010s')."


### PR DESCRIPTION
Adds MARTS.DIM_YEAR (table) populated from INT years with convenience flags (is_current_year, is_last_5_years, decade_start/label). Includes column docs and tests (unique, not_null). No impact on RAW/STAGING.